### PR TITLE
Migrate from `cpp` to `cxx`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,19 @@ jobs:
     - name: Install NNPDF31_nlo_as_0118_luxqed
       run: |
         lhapdf install NNPDF31_nlo_as_0118_luxqed
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+    - name: Install Rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          default: true
+    - name: Run check
+      run: cargo check --verbose
+    - name: Generate doctest coverage
+      uses: actions-rs/tarpaulin@v0.1
+      with:
+        args: --ignore-tests
+        run-types: Doctests,Tests
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,11 +20,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Install LHAPDF 6.3.0
+    - name: Install LHAPDF
       run: |
-        wget 'https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.3.0.tar.gz' -O LHAPDF-6.3.0.tar.gz
-        tar xzf LHAPDF-6.3.0.tar.gz
-        cd LHAPDF-6.3.0
+        echo "LHAPDF=LHAPDF-6.3.0" >> $GITHUB_ENV
+        wget 'https://lhapdf.hepforge.org/downloads/?f=${LHAPDF}.tar.gz' -O ${LHAPDF}.tar.gz
+        tar xzf ${LHAPDF}.tar.gz
+        cd ${LHAPDF}
         ./configure --prefix=${HOME}/prefix
         make -j
         make install

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install LHAPDF
       run: |
         echo "LHAPDF=LHAPDF-6.3.0" >> $GITHUB_ENV
-        wget 'https://lhapdf.hepforge.org/downloads/?f=${LHAPDF}.tar.gz' -O ${LHAPDF}.tar.gz
+        wget "https://lhapdf.hepforge.org/downloads/?f=${LHAPDF}.tar.gz" -O ${LHAPDF}.tar.gz
         tar xzf ${LHAPDF}.tar.gz
         cd ${LHAPDF}
         ./configure --prefix=${HOME}/prefix

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,6 @@
 name: Rust
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [pull_request, push]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,9 @@ jobs:
       with:
         python-version: 3.7
     - name: Install LHAPDF
+      env:
+        LHAPDF: LHAPDF-6.3.0
       run: |
-        echo "LHAPDF=LHAPDF-6.3.0" >> $GITHUB_ENV
         wget "https://lhapdf.hepforge.org/downloads/?f=${LHAPDF}.tar.gz" -O ${LHAPDF}.tar.gz
         tar xzf ${LHAPDF}.tar.gz
         cd ${LHAPDF}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - added function `Pdf::with_setname_and_nmem`
+- changed return type of `PdfSet::uncertainty` to `Result<_>`
 
 ## [0.1.10] - 18/03/2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- added function `Pdf::with_setname_and_nmem`
+
 ## [0.1.10] - 18/03/2021
 
 - added method `PdfSet::error_type`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - added function `Pdf::with_setname_and_nmem`
 - changed return type of `PdfSet::uncertainty` to `Result<_>`
+- added constant `CL_1_SIGMA`
 
 ## [0.1.10] - 18/03/2021
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,9 @@ thiserror = "1.0"
 [build-dependencies]
 cxx-build = "1.0"
 pkg-config = "0.3"
+
+[features]
+docs-only = []
+
+[package.metadata.docs.rs]
+features = [ "docs-only" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,9 @@ categories = ["science"]
 description = "(Unofficial) Rust bindings for the LHAPDF C++ library"
 
 [dependencies]
-cfg-if = "0.1"
-cpp = "0.5"
+cxx = "1.0"
+thiserror = "1.0"
 
 [build-dependencies]
-cpp_build = "0.5"
+cxx-build = "1.0"
 pkg-config = "0.3"
-
-[features]
-docs-only = []
-
-[package.metadata.docs.rs]
-features = [ "docs-only" ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Rust](https://github.com/cschwan/lhapdf/workflows/Rust/badge.svg)](https://github.com/cschwan/lhapdf/actions?query=workflow%3ARust)
+[![codecov](https://codecov.io/gh/cschwan/lhapdf/branch/cxx/graph/badge.svg)](https://codecov.io/gh/cschwan/lhapdf)
 [![Documentation](https://docs.rs/lhapdf/badge.svg)](https://docs.rs/lhapdf)
 [![crates.io](https://img.shields.io/crates/v/lhapdf.svg)](https://crates.io/crates/lhapdf)
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "docs-only"))]
 fn main() {
     let lhapdf = pkg_config::Config::new()
         .atleast_version("6")
@@ -21,5 +22,16 @@ fn main() {
     }
 
     println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=include/wrappers.hpp");
+}
+
+#[cfg(feature = "docs-only")]
+fn main() {
+    cxx_build::bridge("src/lib.rs")
+        .define("FAKE_WRAPPERS", "1")
+        .compile("lhapdf-rust-cxx-bridge");
+
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=include/fake-lhapdf.hpp");
     println!("cargo:rerun-if-changed=include/wrappers.hpp");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,16 @@
-#[cfg(not(feature = "docs-only"))]
 fn main() {
     let lhapdf = pkg_config::Config::new()
         .atleast_version("6")
         .probe("lhapdf")
         .unwrap();
-    let mut cpp_build = cpp_build::Config::new();
+
+    let mut build = cxx_build::bridge("src/lib.rs");
 
     for include_path in lhapdf.include_paths {
-        cpp_build.include(include_path);
+        build.include(include_path);
     }
 
-    cpp_build.build("src/lib.rs");
+    build.compile("lhapdf-rust-cxx-bridge");
 
     for lib_path in lhapdf.link_paths {
         println!("cargo:rustc-link-search={}", lib_path.to_str().unwrap());
@@ -19,7 +19,6 @@ fn main() {
     for lib in lhapdf.libs {
         println!("cargo:rustc-link-lib={}", lib);
     }
-}
 
-#[cfg(feature = "docs-only")]
-fn main() {}
+    println!("cargo:rerun-if-changed=src/lib.rs");
+}

--- a/build.rs
+++ b/build.rs
@@ -21,4 +21,5 @@ fn main() {
     }
 
     println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=include/wrappers.hpp");
 }

--- a/include/fake-lhapdf.hpp
+++ b/include/fake-lhapdf.hpp
@@ -1,0 +1,64 @@
+#ifndef FAKE_LHAPDF_HPP
+#define FAKE_LHAPDF_HPP
+
+#include <cassert>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace LHAPDF {
+
+std::vector<std::string> const& availablePDFSets() {
+    assert(false);
+}
+
+void setVerbosity(int) {
+}
+
+int verbosity() {
+    return 0;
+}
+
+struct PDF {
+    double alphasQ2(double) const {
+        return 0.0;
+    }
+
+    double xfxQ2(int, double, double) const {
+        return 0.0;
+    }
+
+    int lhapdfID() const {
+        return 0;
+    }
+
+    double xMin() {
+        return 0.0;
+    }
+
+    double xMax() {
+        return 1.0;
+    }
+};
+
+struct PDFSet {
+    bool has_key(std::string const&) const {
+        return false;
+    }
+
+    std::string const& get_entry(std::string const&) const {
+        assert(false);
+    }
+
+    std::size_t size() const {
+        return 0;
+    }
+
+    int lhapdfID() const {
+        return 0;
+    }
+};
+
+}
+
+#endif

--- a/include/lhapdf.hpp
+++ b/include/lhapdf.hpp
@@ -1,0 +1,10 @@
+#ifndef LHAPDF_HPP
+#define LHAPDF_HPP
+
+#ifdef FAKE_WRAPPERS
+#include "fake-lhapdf.hpp"
+#else
+#include <LHAPDF/LHAPDF.h>
+#endif
+
+#endif

--- a/include/wrappers.hpp
+++ b/include/wrappers.hpp
@@ -1,7 +1,12 @@
 #ifndef WRAPPERS_HPP
 #define WRAPPERS_HPP
 
+#ifdef FAKE_WRAPPERS
+#include "fake-lhapdf.hpp"
+#else
 #include <LHAPDF/LHAPDF.h>
+#endif
+
 #include <lhapdf/src/lib.rs.h>
 #include <rust/cxx.h>
 
@@ -11,6 +16,47 @@
 #include <vector>
 
 namespace LHAPDF {
+
+#ifdef FAKE_WRAPPERS
+
+inline std::unique_ptr<PDF> pdf_with_setname_and_member(std::string const&, std::int32_t) {
+        return std::unique_ptr<PDF>();
+}
+
+inline std::unique_ptr<PDF> pdf_with_set_and_member(PDFSet const&, std::int32_t) {
+        return std::unique_ptr<PDF>();
+}
+
+inline std::unique_ptr<PDF> pdf_with_setname_and_nmem(std::string const&) {
+        return std::unique_ptr<PDF>();
+}
+
+inline std::unique_ptr<PDF> pdf_with_lhaid(std::int32_t) {
+        return std::unique_ptr<PDF>();
+}
+
+inline std::unique_ptr<PDFSet> pdfset_new(std::string const&) {
+        return std::unique_ptr<PDFSet>();
+}
+
+inline std::unique_ptr<PDFSet> pdfset_from_pdf(PDF const&) {
+        return std::unique_ptr<PDFSet>();
+}
+
+inline void lookup_pdf_setname(std::int32_t, std::string&) {}
+
+inline std::int32_t lookup_pdf_memberid(std::int32_t) {
+        return 0;
+}
+
+inline void get_pdfset_error_type(PDFSet const&, std::string&) {}
+
+inline PdfUncertainty pdf_uncertainty(PDFSet const&, rust::Slice<double const>, double, bool) {
+        PdfUncertainty result;
+            return result;
+}
+
+#else
 
 inline std::unique_ptr<PDF> pdf_with_setname_and_member(
     std::string const& setname,
@@ -77,6 +123,8 @@ inline PdfUncertainty pdf_uncertainty(
 
     return result;
 }
+
+#endif
 
 }
 

--- a/include/wrappers.hpp
+++ b/include/wrappers.hpp
@@ -63,6 +63,7 @@ inline PdfUncertainty pdf_uncertainty(
     std::vector<double> const vector(values.begin(), values.end());
     auto const uncertainty = pdfset.uncertainty(vector, cl, alternative);
 
+    // convert the C++ `PDFUncertainty` to Rust's `PdfUncertainty`
     PdfUncertainty result;
     result.central = uncertainty.central;
     result.errplus = uncertainty.errplus;

--- a/include/wrappers.hpp
+++ b/include/wrappers.hpp
@@ -26,6 +26,10 @@ inline std::unique_ptr<PDF> pdf_with_set_and_member(
     return pdf_with_setname_and_member(set.name(), member);
 }
 
+inline std::unique_ptr<PDF> pdf_with_setname_and_nmem(std::string const& setname_nmem) {
+    return std::unique_ptr<PDF>(mkPDF(setname_nmem));
+}
+
 inline std::unique_ptr<PDF> pdf_with_lhaid(std::int32_t lhaid) {
     return std::unique_ptr<PDF>(mkPDF(lhaid));
 }

--- a/include/wrappers.hpp
+++ b/include/wrappers.hpp
@@ -1,0 +1,78 @@
+#ifndef WRAPPERS_HPP
+#define WRAPPERS_HPP
+
+#include <LHAPDF/LHAPDF.h>
+#include <lhapdf/src/lib.rs.h>
+#include <rust/cxx.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace LHAPDF {
+
+inline std::unique_ptr<PDF> pdf_with_setname_and_member(
+    std::string const& setname,
+    std::int32_t member
+) {
+    return std::unique_ptr<PDF>(mkPDF(setname, member));
+}
+
+inline std::unique_ptr<PDF> pdf_with_set_and_member(
+    PDFSet const& set,
+    std::int32_t member
+) {
+    return pdf_with_setname_and_member(set.name(), member);
+}
+
+inline std::unique_ptr<PDF> pdf_with_lhaid(std::int32_t lhaid) {
+    return std::unique_ptr<PDF>(mkPDF(lhaid));
+}
+
+inline std::unique_ptr<PDFSet> pdfset_new(std::string const& setname) {
+    return std::unique_ptr<PDFSet>(new PDFSet(setname));
+}
+
+inline std::unique_ptr<PDFSet> pdfset_from_pdf(PDF const& pdf) {
+    return std::unique_ptr<PDFSet>(new PDFSet(pdf.set()));
+}
+
+inline void lookup_pdf_setname(std::int32_t lhaid, std::string& setname) {
+    setname = lookupPDF(lhaid).first;
+}
+
+inline std::int32_t lookup_pdf_memberid(std::int32_t lhaid) {
+    return lookupPDF(lhaid).second;
+}
+
+inline void get_pdfset_error_type(PDFSet const& set, std::string& error_type) {
+    error_type = set.errorType();
+}
+
+inline PdfUncertainty pdf_uncertainty(
+    PDFSet const& pdfset,
+    rust::Slice<double const> values,
+    double cl,
+    bool alternative
+) {
+    std::vector<double> const vector(values.begin(), values.end());
+    auto const uncertainty = pdfset.uncertainty(vector, cl, alternative);
+
+    PdfUncertainty result;
+    result.central = uncertainty.central;
+    result.errplus = uncertainty.errplus;
+    result.errminus = uncertainty.errminus;
+    result.errsymm = uncertainty.errsymm;
+    result.scale = uncertainty.scale;
+    result.errplus_pdf = uncertainty.errplus_pdf;
+    result.errminus_pdf = uncertainty.errminus_pdf;
+    result.errsymm_pdf = uncertainty.errsymm_pdf;
+    result.err_par = uncertainty.err_par;
+
+    return result;
+}
+
+}
+
+#endif

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 use cxx::{let_cxx_string, Exception, UniquePtr};
 use std::convert::TryFrom;
+use std::fmt::{self, Formatter};
 use std::result;
 use thiserror::Error;
 
@@ -45,12 +46,14 @@ mod ffi {
 
         fn alphasQ2(self: &PDF, q2: f64) -> Result<f64>;
         fn xfxQ2(self: &PDF, id: i32, x: f64, q2: f64) -> Result<f64>;
+        fn lhapdfID(self: &PDF) -> i32;
 
         type PDFSet;
 
         fn has_key(self: &PDFSet, key: &CxxString) -> bool;
         fn get_entry(self: &PDFSet, key: &CxxString) -> &'static CxxString;
         fn size(self: &PDFSet) -> usize;
+        fn lhapdfID(self: &PDFSet) -> i32;
 
         include!("lhapdf/include/wrappers.hpp");
 
@@ -126,6 +129,14 @@ pub struct Pdf {
     ptr: UniquePtr<ffi::PDF>,
 }
 
+impl fmt::Debug for Pdf {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("Pdf")
+            .field("lhaid", &self.ptr.lhapdfID())
+            .finish()
+    }
+}
+
 impl Pdf {
     /// Constructor. Create a new PDF with the given `lhaid` ID code.
     ///
@@ -185,6 +196,14 @@ unsafe impl Sync for Pdf {}
 /// Class for PDF set metadata and manipulation.
 pub struct PdfSet {
     ptr: UniquePtr<ffi::PDFSet>,
+}
+
+impl fmt::Debug for PdfSet {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("PdfSet")
+            .field("lhaid", &self.ptr.lhapdfID())
+            .finish()
+    }
 }
 
 impl PdfSet {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,13 @@ impl Pdf {
             .map_err(|exc| LhapdfError { exc })
     }
 
-    /// Constructor. Create a new PDF with the given string, which denotes the PDF set and possibly
-    /// also a member number separated by a slash `/` in the string.
+    /// Create a new PDF with the given PDF set name and member ID as a single string.
+    ///
+    /// The format of the `setname_nmem` string is <setname>/<nmem> where <nmem> must be parseable
+    /// as a positive integer. The `/` character is not permitted in set names due to clashes with
+    /// Unix filesystem path syntax.
+    ///
+    /// If no /<nmem> is given, member number 0 will be used.
     ///
     /// # Errors
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,16 +219,11 @@ impl PdfSet {
     }
 
     /// Make all the PDFs in this set.
-    ///
-    /// # Errors
-    ///
-    /// TODO
-    pub fn mk_pdfs(&self) -> Result<Vec<Pdf>> {
+    pub fn mk_pdfs(&self) -> Vec<Pdf> {
         (0..i32::try_from(self.ptr.size()).unwrap_or_else(|_| unreachable!()))
-            .map(|member| {
-                ffi::pdf_with_set_and_member(&self.ptr, member)
-                    .map(|ptr| Pdf { ptr })
-                    .map_err(|exc| LhapdfError { exc })
+            .map(|member| Pdf {
+                ptr: ffi::pdf_with_set_and_member(&self.ptr, member)
+                    .unwrap_or_else(|_| unreachable!()),
             })
             .collect()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod ffi {
     }
 
     unsafe extern "C++" {
-        include!("LHAPDF/LHAPDF.h");
+        include!("lhapdf/include/lhapdf.hpp");
 
         fn availablePDFSets() -> &'static CxxVector<CxxString>;
         fn setVerbosity(verbosity: i32);
@@ -58,7 +58,9 @@ mod ffi {
         fn get_entry(self: &PDFSet, key: &CxxString) -> &'static CxxString;
         fn size(self: &PDFSet) -> usize;
         fn lhapdfID(self: &PDFSet) -> i32;
+    }
 
+    unsafe extern "C++" {
         include!("lhapdf/include/wrappers.hpp");
 
         fn pdf_with_setname_and_member(setname: &CxxString, member: i32) -> Result<UniquePtr<PDF>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ mod test {
 
         assert_eq!(pdf_set.mk_pdfs().len(), 101);
 
-        let uncertainty = pdf_set.uncertainty(&[0.0; 101], 68.268949213709, false);
+        let uncertainty = pdf_set.uncertainty(&[0.0; 101], 68.268949213709, false)?;
 
         assert_eq!(uncertainty.central, 0.0);
         assert_eq!(uncertainty.central, 0.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ use thiserror::Error;
 
 #[cxx::bridge(namespace = "LHAPDF")]
 mod ffi {
+    // The type `PdfUncertainty` must be separate from the one defined in the C++ namespace LHAPDF
+    // because it differs (at least) from LHAPDF 6.4.x to 6.5.x
+
     /// Structure for storage of uncertainty info calculated over a PDF error set.
     struct PdfUncertainty {
         /// The central value.
@@ -74,7 +77,7 @@ mod ffi {
             values: &[f64],
             cl: f64,
             alternative: bool,
-        ) -> PdfUncertainty;
+        ) -> Result<PdfUncertainty>;
     }
 }
 
@@ -309,8 +312,13 @@ impl PdfSet {
     /// is available. The parameter variation uncertainties are computed from the last `2*n`
     /// members of the set, with `n` the number of parameters.
     #[must_use]
-    pub fn uncertainty(&self, values: &[f64], cl: f64, alternative: bool) -> PdfUncertainty {
-        ffi::pdf_uncertainty(&self.ptr, values, cl, alternative)
+    pub fn uncertainty(
+        &self,
+        values: &[f64],
+        cl: f64,
+        alternative: bool,
+    ) -> Result<PdfUncertainty> {
+        ffi::pdf_uncertainty(&self.ptr, values, cl, alternative).map_err(|exc| LhapdfError { exc })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,234 +1,180 @@
 #![warn(clippy::all, clippy::cargo, clippy::nursery, clippy::pedantic)]
 #![warn(missing_docs)]
+#![allow(clippy::use_self)] // TODO: remove this line
 
 //! (Unofficial) Rust wrapper for the [LHAPDF](https://lhapdf.hepforge.org) C++ library.
 
-#[macro_use]
-extern crate cfg_if;
+use cxx::{let_cxx_string, Exception, UniquePtr};
+use std::convert::TryFrom;
+use std::result;
+use thiserror::Error;
 
-use std::ffi::c_void;
+#[cxx::bridge(namespace = "LHAPDF")]
+mod ffi {
+    /// Structure for storage of uncertainty info calculated over a PDF error set.
+    struct PdfUncertainty {
+        /// The central value.
+        pub central: f64,
+        /// The unsymmetric error in positive direction.
+        pub errplus: f64,
+        /// The unsymmetric error in negative direction.
+        pub errminus: f64,
+        /// The symmetric error.
+        pub errsymm: f64,
+        /// The scale factor needed to convert between the PDF set's default confidence level and
+        /// the requested confidence level.
+        pub scale: f64,
+        /// Extra variable for separate PDF and parameter variation errors with combined sets.
+        pub errplus_pdf: f64,
+        /// Extra variable for separate PDF and parameter variation errors with combined sets.
+        pub errminus_pdf: f64,
+        /// Extra variable for separate PDF and parameter variation errors with combined sets.
+        pub errsymm_pdf: f64,
+        /// Extra variable for separate PDF and parameter variation errors with combined sets.
+        pub err_par: f64,
+    }
 
-cfg_if! {
-    if #[cfg(not(feature = "docs-only"))] {
-        #[macro_use]
-        extern crate cpp;
+    unsafe extern "C++" {
+        include!("LHAPDF/LHAPDF.h");
 
-        use std::ffi::{CStr, CString};
-        use std::os::raw::c_char;
+        fn availablePDFSets() -> &'static CxxVector<CxxString>;
+        fn setVerbosity(verbosity: i32);
+        fn verbosity() -> i32;
 
-        cpp! {{
-            #include <cstring>
-            #include <cstddef>
-            #include <LHAPDF/LHAPDF.h>
-        }}
-    } else {
-        use std::ptr;
+        type PDF;
+
+        fn alphasQ2(self: &PDF, q2: f64) -> Result<f64>;
+        fn xfxQ2(self: &PDF, id: i32, x: f64, q2: f64) -> Result<f64>;
+
+        type PDFSet;
+
+        fn has_key(self: &PDFSet, key: &CxxString) -> bool;
+        fn get_entry(self: &PDFSet, key: &CxxString) -> &'static CxxString;
+        fn size(self: &PDFSet) -> usize;
+
+        include!("lhapdf/include/wrappers.hpp");
+
+        fn pdf_with_setname_and_member(setname: &CxxString, member: i32) -> Result<UniquePtr<PDF>>;
+        fn pdf_with_set_and_member(set: &PDFSet, member: i32) -> Result<UniquePtr<PDF>>;
+        fn pdf_with_lhaid(lhaid: i32) -> Result<UniquePtr<PDF>>;
+        fn pdfset_new(setname: &CxxString) -> Result<UniquePtr<PDFSet>>;
+        fn pdfset_from_pdf(pdf: &PDF) -> UniquePtr<PDFSet>;
+
+        fn lookup_pdf_setname(lhaid: i32, setname: Pin<&mut CxxString>);
+        fn lookup_pdf_memberid(lhaid: i32) -> i32;
+        fn get_pdfset_error_type(set: &PDFSet, setname: Pin<&mut CxxString>);
+
+        fn pdf_uncertainty(
+            pdfset: &PDFSet,
+            values: &[f64],
+            cl: f64,
+            alternative: bool,
+        ) -> PdfUncertainty;
     }
 }
+
+/// Error struct that wraps all exceptions thrown by the LHAPDF library.
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct LhapdfError {
+    exc: Exception,
+}
+
+/// Type definition for results with an [`LhapdfError`].
+pub type Result<T> = result::Result<T, LhapdfError>;
+
+pub use ffi::PdfUncertainty;
 
 /// Get the names of all available PDF sets in the search path.
 #[must_use]
 pub fn available_pdf_sets() -> Vec<String> {
-    cfg_if! {
-        if #[cfg(feature = "docs-only")] {
-            vec![]
-        } else {
-            let pdfs = unsafe {
-                cpp!([] -> usize as "size_t" {
-                    return static_cast<unsigned> (LHAPDF::availablePDFSets().size());
-                })
-            };
-
-            let mut pdf_sets: Vec<String> = Vec::with_capacity(pdfs);
-
-            for i in 0..pdfs {
-                let cstr_ptr = unsafe {
-                    cpp!([i as "size_t"] -> *const c_char as "const char *" {
-                        return LHAPDF::availablePDFSets().at(i).c_str();
-                    })
-                };
-                pdf_sets.push(
-                    unsafe { CStr::from_ptr(cstr_ptr) }
-                        .to_str()
-                        .unwrap()
-                        .to_string(),
-                );
-            }
-
-            pdf_sets
-        }
-    }
+    ffi::availablePDFSets()
+        .iter()
+        .map(|s| s.to_string_lossy().into_owned())
+        .collect()
 }
 
-/// Look up a PDF set name and member ID by the LHAPDF ID code. The set name and member ID are
-/// returned as a tuple in an `Option`. If lookup fails, `None` is returned.
+/// Convert an LHAID to an LHAPDF set name and member ID.
 #[must_use]
 pub fn lookup_pdf(lhaid: i32) -> Option<(String, i32)> {
-    cfg_if! {
-        if #[cfg(feature = "docs-only")] {
-            None
-        } else {
-            let pair = unsafe {
-                cpp!([lhaid as "int"] -> *const c_void as "const void *" {
-                    return new std::pair<std::string, int>(LHAPDF::lookupPDF(lhaid));
-                })
-            };
+    let_cxx_string!(cxx_setname = "");
+    ffi::lookup_pdf_setname(lhaid, cxx_setname.as_mut());
 
-            let set_name = unsafe { CStr::from_ptr(
-                cpp!([pair as "std::pair<std::string, int>*"] -> *const c_char as "const char *" {
-                    return pair->first.c_str();
-                }))
-            }.to_str().unwrap().to_string();
-            let member_id = unsafe {
-                cpp!([pair as "std::pair<std::string, int>*"] -> i32 as "int" {
-                    return pair->second;
-                })
-            };
+    let setname = cxx_setname.to_string_lossy();
+    let memberid = ffi::lookup_pdf_memberid(lhaid);
 
-            unsafe {
-                cpp!([pair as "std::pair<std::string, int>*"] -> () as "void" {
-                    return delete pair;
-                })
-            };
-
-            if (set_name == String::new()) && (member_id == -1) {
-                return None;
-            }
-
-            Some((set_name, member_id))
-        }
+    if (setname == "") && (memberid == -1) {
+        None
+    } else {
+        Some((setname.to_string(), memberid))
     }
 }
 
 /// Convenient way to set the verbosity level.
 pub fn set_verbosity(verbosity: i32) {
-    cfg_if! {
-        if #[cfg(feature = "docs-only")] {
-        } else {
-            unsafe {
-                cpp!([verbosity as "int"] { LHAPDF::setVerbosity(verbosity); });
-            }
-        }
-    }
+    ffi::setVerbosity(verbosity);
 }
 
 /// Convenient way to get the current verbosity level.
 #[must_use]
 pub fn verbosity() -> i32 {
-    cfg_if! {
-        if #[cfg(feature = "docs-only")] {
-            -1
-        } else {
-            unsafe {
-                cpp!([] -> i32 as "int" { return LHAPDF::verbosity(); })
-            }
-        }
-    }
+    ffi::verbosity()
 }
 
 /// Wrapper to an LHAPDF object of the type `LHAPDF::PDF`.
 pub struct Pdf {
-    ptr: *mut c_void,
+    ptr: UniquePtr<ffi::PDF>,
 }
 
 impl Pdf {
-    /// Constructor. Create a new PDF with the given PDF `setname` and `member` ID.
-    #[must_use]
-    pub fn with_setname_and_member(setname: &str, member: i32) -> Self {
-        cfg_if! {
-            if #[cfg(feature = "docs-only")] {
-                Self { ptr: ptr::null_mut::<c_void>() }
-            } else {
-                let setname = CString::new(setname).unwrap();
-                let setname_ptr = setname.as_ptr();
-
-                Self {
-                    ptr: unsafe {
-                        cpp!([setname_ptr as "const char *",
-                              member as "int"] -> *mut c_void as "LHAPDF::PDF*" {
-                            return LHAPDF::mkPDF(setname_ptr, member);
-                        })
-                    },
-                }
-            }
-        }
+    /// Constructor. Create a new PDF with the given `lhaid` ID code.
+    ///
+    /// # Errors
+    ///
+    /// TODO
+    pub fn with_lhaid(lhaid: i32) -> Result<Self> {
+        ffi::pdf_with_lhaid(lhaid)
+            .map(|ptr| Self { ptr })
+            .map_err(|exc| LhapdfError { exc })
     }
 
-    /// Constructor. Create a new PDF with the given `lhaid` ID code.
-    #[must_use]
-    pub fn with_lhaid(lhaid: i32) -> Self {
-        cfg_if! {
-            if #[cfg(feature = "docs-only")] {
-                Self { ptr: ptr::null_mut::<c_void>() }
-            } else {
-                Self {
-                    ptr: unsafe {
-                        cpp!([lhaid as "int"] -> *mut c_void as "LHAPDF::PDF*" {
-                            return LHAPDF::mkPDF(lhaid);
-                        })
-                    },
-                }
-            }
-        }
+    /// Constructor. Create a new PDF with the given PDF `setname` and `member` ID.
+    ///
+    /// # Errors
+    ///
+    /// TODO
+    pub fn with_setname_and_member(setname: &str, member: i32) -> Result<Self> {
+        let_cxx_string!(cxx_setname = setname.to_string());
+        ffi::pdf_with_setname_and_member(&cxx_setname, member)
+            .map(|ptr| Self { ptr })
+            .map_err(|exc| LhapdfError { exc })
     }
 
     /// Get the PDF `x * f(x)` value at `x` and `q2` for the given PDG ID.
+    ///
+    /// # Panics
+    ///
+    /// If the value of either `x` or `q2` is not within proper boundaries this method will panic.
     #[must_use]
     pub fn xfx_q2(&self, id: i32, x: f64, q2: f64) -> f64 {
-        cfg_if! {
-            if #[cfg(feature = "docs-only")] {
-                0.0
-            } else {
-                let self_ptr = self.ptr;
-
-                unsafe {
-                    cpp!([self_ptr as "LHAPDF::PDF *",
-                                   id as "int",
-                                   x as "double",
-                                   q2 as "double"] -> f64 as "double" {
-                        return self_ptr->xfxQ2(id, x, q2);
-                    })
-                }
-            }
-        }
+        self.ptr.xfxQ2(id, x, q2).unwrap()
     }
 
     /// Value of of the strong coupling at `q2` used by this PDF.
+    ///
+    /// # Panics
+    ///
+    /// If the value of `q2` is not within proper boundaries this method will panic.
     #[must_use]
     pub fn alphas_q2(&self, q2: f64) -> f64 {
-        cfg_if! {
-            if #[cfg(feature = "docs-only")] {
-                0.0
-            } else {
-                let self_ptr = self.ptr;
-
-                unsafe {
-                    cpp!([self_ptr as "LHAPDF::PDF *", q2 as "double"] -> f64 as "double" {
-                        return self_ptr->alphasQ2(q2);
-                    })
-                }
-            }
-        }
+        self.ptr.alphasQ2(q2).unwrap()
     }
 
     /// Get the info class that actually stores and handles the metadata.
     #[must_use]
     pub fn set(&self) -> PdfSet {
-        cfg_if! {
-            if #[cfg(not(feature = "docs-only"))] {
-                let self_ptr = self.ptr;
-
-                PdfSet {
-                    ptr: unsafe {
-                        cpp!([self_ptr as "LHAPDF::PDF *"] -> *mut c_void as "LHAPDF::PDFSet *" {
-                            return &self_ptr->set();
-                        })
-                    },
-                    drop: false,
-                }
-            } else {
-                PdfSet { ptr: ptr::null_mut::<c_void>(), drop: false }
-            }
+        PdfSet {
+            ptr: ffi::pdfset_from_pdf(&self.ptr),
         }
     }
 }
@@ -236,166 +182,55 @@ impl Pdf {
 unsafe impl Send for Pdf {}
 unsafe impl Sync for Pdf {}
 
-impl Drop for Pdf {
-    fn drop(&mut self) {
-        cfg_if! {
-            if #[cfg(not(feature = "docs-only"))] {
-                let self_ptr = self.ptr;
-
-                unsafe {
-                    cpp!([self_ptr as "LHAPDF::PDF *"] -> () as "void" {
-                        delete self_ptr;
-                    });
-                }
-            }
-        }
-    }
-}
-
-/// Structure for storage of uncertainty info calculated over a PDF error set.
-pub struct PdfUncertainty {
-    /// The central value.
-    pub central: f64,
-    /// The unsymmetric error in positive direction.
-    pub errplus: f64,
-    /// The unsymmetric error in negative direction.
-    pub errminus: f64,
-    /// The symmetric error.
-    pub errsymm: f64,
-    /// The scale factor needed to convert between the PDF set's default confidence level and the
-    /// requested confidence level.
-    pub scale: f64,
-    /// Extra variable for separate PDF and parameter variation errors with combined sets.
-    pub errplus_pdf: f64,
-    /// Extra variable for separate PDF and parameter variation errors with combined sets.
-    pub errminus_pdf: f64,
-    /// Extra variable for separate PDF and parameter variation errors with combined sets.
-    pub errsymm_pdf: f64,
-    /// Extra variable for separate PDF and parameter variation errors with combined sets.
-    pub err_par: f64,
-}
-
 /// Class for PDF set metadata and manipulation.
 pub struct PdfSet {
-    ptr: *mut c_void,
-    drop: bool,
+    ptr: UniquePtr<ffi::PDFSet>,
 }
 
 impl PdfSet {
     /// Constructor from a set name.
     #[must_use]
-    pub fn new(setname: &str) -> Self {
-        cfg_if! {
-            if #[cfg(feature = "docs-only")] {
-                Self { ptr: ptr::null_mut::<c_void>(), drop: false }
-            } else {
-                let setname = CString::new(setname).unwrap();
-                let setname_ptr = setname.as_ptr();
+    pub fn new(setname: &str) -> Result<Self> {
+        let_cxx_string!(cxx_setname = setname);
 
-                Self {
-                    ptr: unsafe {
-                        cpp!([setname_ptr as "const char *"] -> *mut c_void as "LHAPDF::PDFSet *" {
-                            return new LHAPDF::PDFSet(setname_ptr);
-                        })
-                    },
-                    drop: true
-                }
-            }
-        }
+        ffi::pdfset_new(&cxx_setname)
+            .map(|ptr| Self { ptr })
+            .map_err(|exc| LhapdfError { exc })
     }
 
     /// Retrieve a metadata string by key name.
     #[must_use]
     pub fn entry(&self, key: &str) -> Option<String> {
-        cfg_if! {
-            if #[cfg(feature = "docs-only")] {
-                None
-            } else {
-                let self_ptr = self.ptr;
-                let key = CString::new(key).unwrap();
-                let key_ptr = key.as_ptr();
+        let_cxx_string!(cxx_key = key);
 
-                unsafe {
-                    let has_key = cpp!([self_ptr as "LHAPDF::PDFSet*", key_ptr as "const char*"] -> bool as "bool" {
-                        return self_ptr->has_key(key_ptr);
-                    });
-
-                    if has_key {
-                        let size = cpp!([self_ptr as "LHAPDF::PDFSet*", key_ptr as "const char*"] -> usize as "std::size_t" {
-                            auto const& value = self_ptr->get_entry(key_ptr);
-                            return value.size();
-                        });
-                        let value_ptr = CString::new(vec![b' '; size]).unwrap().into_raw();
-                        cpp!([self_ptr as "LHAPDF::PDFSet*", key_ptr as "const char*", value_ptr as "char*"] {
-                            auto const& value = self_ptr->get_entry(key_ptr);
-                            std::strncpy(value_ptr, value.c_str(), value.size() + 1);
-                        });
-                        Some(CString::from_raw(value_ptr).into_string().unwrap())
-                    } else {
-                        None
-                    }
-                }
-            }
+        if self.ptr.has_key(&cxx_key) {
+            Some(self.ptr.get_entry(&cxx_key).to_string_lossy().into_owned())
+        } else {
+            None
         }
     }
 
     /// Get the type of PDF errors in this set (replicas, symmhessian, hessian, custom, etc.).
     pub fn error_type(&self) -> String {
-        cfg_if! {
-            if #[cfg(feature = "docs-only")] {
-                "".to_owned()
-            } else {
-                let self_ptr = self.ptr;
+        let_cxx_string!(string = "");
 
-                unsafe {
-                    let string = cpp!([self_ptr as "LHAPDF::PDFSet*"] -> *mut c_void as "std::string*" {
-                        return new std::string(self_ptr->errorType());
-                    });
-                    let cstr = cpp!([string as "std::string*"] -> *const c_char as "const char*" {
-                        return string->c_str();
-                    });
-
-                    let converted = CStr::from_ptr(cstr).to_str().unwrap().to_string();
-
-                    cpp!([string as "std::string*"] { delete string; });
-
-                    converted
-                }
-            }
-        }
+        ffi::get_pdfset_error_type(&self.ptr, string.as_mut());
+        string.to_string_lossy().into_owned()
     }
 
     /// Make all the PDFs in this set.
-    pub fn mk_pdfs(&self) -> Vec<Pdf> {
-        cfg_if! {
-            if #[cfg(feature = "docs-only")] {
-                vec![]
-            } else {
-                let self_ptr = self.ptr;
-                let mut pdfs = vec![];
-
-                unsafe {
-                    let vec = cpp!([self_ptr as "LHAPDF::PDFSet*"] -> *mut c_void as "std::vector<LHAPDF::PDF*>*" {
-                        return new std::vector<LHAPDF::PDF*>(self_ptr->mkPDFs());
-                    });
-                    let size = cpp!([vec as "std::vector<LHAPDF::PDF*>*"] -> usize as "std::size_t" {
-                        return vec->size();
-                    });
-
-                    for index in 0..size {
-                        pdfs.push(Pdf { ptr: cpp!([vec as "std::vector<LHAPDF::PDF*>*", index as "std::size_t"] -> *mut c_void as "LHAPDF::PDF*" {
-                            return vec->at(index);
-                        }) });
-                    }
-
-                    cpp!([vec as "std::vector<LHAPDF::PDF*>*"] -> () as "void" {
-                        delete vec;
-                    });
-                }
-
-                pdfs
-            }
-        }
+    ///
+    /// # Errors
+    ///
+    /// TODO
+    pub fn mk_pdfs(&self) -> Result<Vec<Pdf>> {
+        (0..i32::try_from(self.ptr.size()).unwrap_or_else(|_| unreachable!()))
+            .map(|member| {
+                ffi::pdf_with_set_and_member(&self.ptr, member)
+                    .map(|ptr| Pdf { ptr })
+                    .map_err(|exc| LhapdfError { exc })
+            })
+            .collect()
     }
 
     /// Calculate central value and error from vector values with appropriate formulae for this
@@ -404,11 +239,11 @@ impl PdfSet {
     /// Warning: The values vector corresponds to the members of this PDF set and must be ordered
     /// accordingly.
     ///
-    /// In the Hessian approach, the central value is the best-fit "values[0]" and the uncertainty
+    /// In the Hessian approach, the central value is the best-fit "values\[0\]" and the uncertainty
     /// is given by either the symmetric or asymmetric formula using eigenvector PDF sets.
     ///
     /// If the PDF set is given in the form of replicas, by default, the central value is given by
-    /// the mean and is not necessarily "values[0]" for quantities with a non-linear dependence on
+    /// the mean and is not necessarily "values\[0]\" for quantities with a non-linear dependence on
     /// PDFs, while the uncertainty is given by the standard deviation.
     ///
     /// The argument `cl` is used to rescale uncertainties to a particular confidence level (in
@@ -424,75 +259,7 @@ impl PdfSet {
     /// members of the set, with `n` the number of parameters.
     #[must_use]
     pub fn uncertainty(&self, values: &[f64], cl: f64, alternative: bool) -> PdfUncertainty {
-        let mut central = 0.0;
-        let mut errplus = 0.0;
-        let mut errminus = 0.0;
-        let mut errsymm = 0.0;
-        let mut scale = 0.0;
-        let mut errplus_pdf = 0.0;
-        let mut errminus_pdf = 0.0;
-        let mut errsymm_pdf = 0.0;
-        let mut err_par = 0.0;
-
-        cfg_if! {
-            if #[cfg(not(feature = "docs-only"))] {
-                let self_ptr = self.ptr;
-                let values_ptr = values.as_ptr();
-                let values_len = values.len();
-
-                unsafe {
-                    cpp!([self_ptr as "LHAPDF::PDFSet *", values_ptr as "double *",
-                          values_len as "std::size_t", cl as "double", alternative as "bool",
-                          mut central as "double", mut errplus as "double",
-                          mut errminus as "double", mut errsymm as "double", mut scale as "double",
-                          mut errplus_pdf as "double", mut errminus_pdf as "double",
-                          mut errsymm_pdf as "double", mut err_par as "double"] -> () as "void" {
-                        LHAPDF::PDFUncertainty res;
-                        std::vector<double> vec_values(values_ptr, values_ptr + values_len);
-                        self_ptr->uncertainty(res, vec_values, cl, alternative);
-                        central = res.central;
-                        errplus = res.errplus;
-                        errminus = res.errminus;
-                        errsymm = res.errsymm;
-                        scale = res.scale;
-                        errplus_pdf = res.errplus_pdf;
-                        errminus_pdf = res.errminus_pdf;
-                        errsymm_pdf = res.errsymm_pdf;
-                        err_par = res.err_par;
-                    });
-                }
-            }
-        }
-
-        PdfUncertainty {
-            central,
-            errplus,
-            errminus,
-            errsymm,
-            scale,
-            errplus_pdf,
-            errminus_pdf,
-            errsymm_pdf,
-            err_par,
-        }
-    }
-}
-
-impl Drop for PdfSet {
-    fn drop(&mut self) {
-        if self.drop {
-            cfg_if! {
-                 if #[cfg(not(feature = "docs-only"))] {
-                    let self_ptr = self.ptr;
-
-                    unsafe {
-                        cpp!([self_ptr as "LHAPDF::PDFSet *"] -> () as "void" {
-                            delete self_ptr;
-                        })
-                    }
-                }
-            }
-        }
+        ffi::pdf_uncertainty(&self.ptr, values, cl, alternative)
     }
 }
 
@@ -501,12 +268,18 @@ mod test {
     use super::*;
 
     #[test]
-    fn check_available_pdf_sets() {
-        let pdf_sets = available_pdf_sets();
+    fn available_pdf_sets() {
+        let pdf_sets = super::available_pdf_sets();
 
         assert!(pdf_sets
             .iter()
             .any(|pdf_set| pdf_set == "NNPDF31_nlo_as_0118_luxqed"));
+    }
+
+    #[test]
+    fn set_verbosity() {
+        super::set_verbosity(0);
+        assert_eq!(verbosity(), 0);
     }
 
     #[test]
@@ -519,9 +292,9 @@ mod test {
     }
 
     #[test]
-    fn check_pdf() {
-        let pdf_0 = Pdf::with_setname_and_member("NNPDF31_nlo_as_0118_luxqed", 0);
-        let pdf_1 = Pdf::with_lhaid(324900);
+    fn check_pdf() -> Result<()> {
+        let pdf_0 = Pdf::with_setname_and_member("NNPDF31_nlo_as_0118_luxqed", 0)?;
+        let pdf_1 = Pdf::with_lhaid(324900)?;
 
         let value_0 = pdf_0.xfx_q2(2, 0.5, 90.0 * 90.0);
         let value_1 = pdf_1.xfx_q2(2, 0.5, 90.0 * 90.0);
@@ -534,16 +307,20 @@ mod test {
 
         assert_ne!(value_0, 0.0);
         assert_eq!(value_0, value_1);
+
+        Ok(())
     }
 
     #[test]
-    fn check_pdf_set() {
-        let pdf_set = PdfSet::new("NNPDF31_nlo_as_0118_luxqed");
+    fn check_pdf_set() -> Result<()> {
+        let pdf_set = PdfSet::new("NNPDF31_nlo_as_0118_luxqed")?;
 
         assert!(matches!(pdf_set.entry("Particle"), Some(value) if value == "2212"));
         assert!(matches!(pdf_set.entry("Flavors"), Some(value)
             if value == "[-5, -4, -3, -2, -1, 21, 1, 2, 3, 4, 5, 22]"));
 
         assert_eq!(pdf_set.error_type(), "replicas");
+
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all, clippy::cargo, clippy::nursery, clippy::pedantic)]
 #![warn(missing_docs)]
-#![allow(clippy::use_self)] // TODO: remove this line
 
 //! (Unofficial) Rust wrapper for the [LHAPDF](https://lhapdf.hepforge.org) C++ library.
 
@@ -236,7 +235,10 @@ impl fmt::Debug for PdfSet {
 
 impl PdfSet {
     /// Constructor from a set name.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// If the PDF set with the specified name was not found an error is returned.
     pub fn new(setname: &str) -> Result<Self> {
         let_cxx_string!(cxx_setname = setname);
 
@@ -258,6 +260,7 @@ impl PdfSet {
     }
 
     /// Get the type of PDF errors in this set (replicas, symmhessian, hessian, custom, etc.).
+    #[must_use]
     pub fn error_type(&self) -> String {
         let_cxx_string!(string = "");
 
@@ -266,6 +269,7 @@ impl PdfSet {
     }
 
     /// Make all the PDFs in this set.
+    #[must_use]
     pub fn mk_pdfs(&self) -> Vec<Pdf> {
         (0..i32::try_from(self.ptr.size()).unwrap_or_else(|_| unreachable!()))
             .map(|member| Pdf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,9 @@ pub struct LhapdfError {
     exc: Exception,
 }
 
+/// CL percentage for a Gaussian 1-sigma.
+pub const CL_1_SIGMA: f64 = 68.268_949_213_708_58;
+
 /// Type definition for results with an [`LhapdfError`].
 pub type Result<T> = result::Result<T, LhapdfError>;
 


### PR DESCRIPTION
- there are still a few TODOs to fix
- documentation will not be generated on docs.rs, because the LHAPDF library is missing and I removed the `docs-only` feature